### PR TITLE
Dynamically create base url

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,16 +1,15 @@
 import { createEnv } from "@t3-oss/env-nextjs";
+import { vercel } from "@t3-oss/env-nextjs/presets-zod";
 import { z } from "zod";
 
 export const env = createEnv({
+  extends: [vercel()],
   server: {
     DATABASE_URL: z.string(),
     BETTER_AUTH_SECRET: z.string().length(32),
-    BETTER_AUTH_URL: z.url(),
   },
-  // If you're using Next.js < 13.4.4, you'll need to specify the runtimeEnv manually
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
     BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-    BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
   },
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,12 +2,20 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
+import { env } from "@/env";
+
+const baseUrl =
+  env.VERCEL_ENV === "production"
+    ? `https://${env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : env.VERCEL_ENV === "preview"
+    ? `https://${env.VERCEL_URL}`
+    : "http://localhost:3000";
 
 export const auth = betterAuth({
+  baseURL: baseUrl,
   emailAndPassword: {
     enabled: true,
   },
-
   database: drizzleAdapter(db, {
     provider: "pg", // or "mysql", "sqlite
     schema,


### PR DESCRIPTION
Initially, the base url for use by the `auth` instance was specified as an environment variable. 

For more control (e.g. the ability to dynamically set it to the URL provided by Vercel when deployed to either a preview or production environment), the former approach is traded for initializing the base url in code.